### PR TITLE
Added confirm password field validation #77

### DIFF
--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux'
 
 import { useModalContext } from '~/context/modal-context'
 import { useSnackBarContext } from '~/context/snackbar-context'
+import { confirmPassword } from '~/utils/validations/login'
 import useConfirm from '~/hooks/use-confirm'
 import useForm from '~/hooks/use-form'
 
@@ -62,7 +63,8 @@ const SignupDialog = ({ type }) => {
         email: '',
         password: '',
         confirmPassword: ''
-      }
+      },
+      validations: { confirmPassword }
     })
 
   const description = (

--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -116,6 +116,7 @@ const SignupForm = ({
 
       <AppTextField
         InputProps={confirmPasswordVisibility}
+        errorMsg={t(errors['confirmPassword'])}
         fullWidth
         label={t('common.labels.confirmPassword')}
         onBlur={handleBlur('confirmPassword')}

--- a/src/utils/validations/login.js
+++ b/src/utils/validations/login.js
@@ -19,7 +19,7 @@ export const lastName = (value) => {
 export const confirmPassword = (password, data) => {
   return emptyField(
     password,
-    'common.errorMessages.emptyField',
-    password !== data.password ? 'common.errorMessages.emptyField' : ''
+    'common.errorMessages.passwordsDontMatch',
+    password !== data.password ? 'common.errorMessages.passwordsDontMatch' : ''
   )
 }


### PR DESCRIPTION
Before:
No error is shown, system validates invalid 'Confirm 'Password' data as matching.
![image](https://github.com/Space2Study-UA-1156/Client-02/assets/65496114/58497661-4776-4cbb-8e49-5340d73d9436)

After:
The red error text 'Passwords do not match' is shown under 'Confirm 'Password' field when it is filled with invalid data.
![image](https://github.com/Space2Study-UA-1156/Client-02/assets/65496114/3c9ce1c4-c7f0-4a13-a3b2-6d732a2dc452)
