### PR TITLE
Disable "Send me password reset link" button if email is not entered #166

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
@@ -76,6 +76,10 @@ const ForgotPassword = () => {
     </Typography>
   )
 
+  const buttonValidate = (errors, data) => {
+    return errors.length > 0 || data.length === 0
+  }
+
   return (
     <Box sx={styles.root}>
       <TitleWithDescription
@@ -98,7 +102,12 @@ const ForgotPassword = () => {
           type='email'
           value={data.email}
         />
-        <AppButton loading={loading} sx={styles.sentPassword} type='submit'>
+        <AppButton
+          disabled={buttonValidate(errors.email, data.email)}
+          loading={loading}
+          sx={styles.sentPassword}
+          type='submit'
+        >
           {t('login.sendPassword')}
         </AppButton>
       </Box>


### PR DESCRIPTION
before, the "Send me password reset link" was always clickable all the time. 

now, the button disabled "Send me password reset link" for certain conditions: 
- if there is nothing inside the input
- if the validation error pops up

https://github.com/Space2Study-UA-1156/Client-02/assets/102433497/9a48980b-66f8-4b3c-991b-6abb3d37e494

