### PR TITLE
Removed "Back" button from the first "General Info" step #183

### DIFF
--- a/src/components/step-wrapper/StepWrapper.jsx
+++ b/src/components/step-wrapper/StepWrapper.jsx
@@ -12,9 +12,10 @@ import { styles } from '~/components/step-wrapper/StepWrapper.styles'
 import useSteps from '~/hooks/use-steps'
 
 const StepWrapper = ({ children, steps }) => {
-  const { activeStep, isLastStep, loading, stepOperation } = useSteps({
-    steps
-  })
+  const { activeStep, isFirstStep, isLastStep, loading, stepOperation } =
+    useSteps({
+      steps
+    })
   const { next, back, setActiveStep, handleSubmit } = stepOperation
   const { t } = useTranslation()
 
@@ -47,17 +48,23 @@ const StepWrapper = ({ children, steps }) => {
   )
 
   const btnsBox = (
-    <Box sx={styles.btnWrapper}>
-      <AppButton
-        disabled={activeStep === 0}
-        onClick={back}
-        size='small'
-        sx={styles.btn}
-        variant='outlined'
-      >
-        <WestIcon fontSize='small' />
-        {t('common.back')}
-      </AppButton>
+    <Box
+      sx={{
+        ...styles.btnWrapper,
+        justifyContent: isFirstStep ? 'flex-end' : 'space-between'
+      }}
+    >
+      {!isFirstStep && (
+        <AppButton
+          onClick={back}
+          size='small'
+          sx={styles.btn}
+          variant='outlined'
+        >
+          <WestIcon fontSize='small' />
+          {t('common.back')}
+        </AppButton>
+      )}
       {nextButton}
     </Box>
   )

--- a/src/components/step-wrapper/StepWrapper.styles.js
+++ b/src/components/step-wrapper/StepWrapper.styles.js
@@ -47,7 +47,6 @@ export const styles = {
   },
   btnWrapper: {
     display: 'flex',
-    justifyContent: 'space-between',
     mt: '10px',
     maxHeight: '40px'
   },

--- a/src/hooks/use-steps.jsx
+++ b/src/hooks/use-steps.jsx
@@ -51,6 +51,7 @@ const useSteps = ({ steps }) => {
   }
 
   const isLastStep = activeStep === steps.length - 1
+  const isFirstStep = activeStep === 0
 
   const handleSubmit = () => {
     handleResponse()
@@ -63,7 +64,7 @@ const useSteps = ({ steps }) => {
     setActiveStep
   }
 
-  return { activeStep, isLastStep, stepOperation, loading }
+  return { activeStep, isFirstStep, isLastStep, stepOperation, loading }
 }
 
 export default useSteps


### PR DESCRIPTION
### Removed "Back" button from the first "`General Info`" step [ Close #183 ]

| Before changing | After changing |
|-----------------|----------------|
| ![Before changing](https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/7269da78-8435-4bf6-81e6-5e59f711db6b) | ![After changing](https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/5e455047-9e76-4a22-a88b-02883c412b13) |


| Before changing | After changing |
|-----------------|----------------|
| <img width="552" alt="Screenshot 2024-05-15 at 15 21 30" src="https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/01176a53-3cd1-4c54-82b4-a03dcb8d1c33"> | <img width="552" alt="Screenshot 2024-05-15 at 15 21 01" src="https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/9b644194-7acf-4775-9004-d7e0c3928b96"> |

