### PR TITLE
Creating "User Request" service & Sending user request data for creating a new category/subject to the server #221

### DIFF
--- a/src/components/category-search-section/CategorySearchSection.jsx
+++ b/src/components/category-search-section/CategorySearchSection.jsx
@@ -1,8 +1,10 @@
-import { Box, Typography, Paper, Autocomplete, TextField } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import SearchIcon from '@mui/icons-material/Search'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import { useTranslation } from 'react-i18next'
+import { Box, Typography, Paper, Autocomplete, TextField } from '@mui/material'
 import HashLink from '~/components/hash-link/HashLink'
+import RequestNewCategoryDialog from '~/containers/student-home-page/request-new-category/request-new-category-dialog/RequestNewCategoryDialog'
+import { useModalContext } from '~/context/modal-context'
 
 const CategorySearch = ({
   inputValue,
@@ -17,6 +19,11 @@ const CategorySearch = ({
   normalizeString
 }) => {
   const { t } = useTranslation()
+  const { openModal } = useModalContext()
+
+  const openCreateNewUserRequestDialog = () => {
+    openModal({ component: <RequestNewCategoryDialog /> })
+  }
 
   return (
     <>
@@ -70,6 +77,7 @@ const CategorySearch = ({
         <Typography>{t('categoriesPage.cantFindLabel')}</Typography>
         <Typography
           component={HashLink}
+          onClick={openCreateNewUserRequestDialog}
           sx={styles.underlineText}
           to={categoriesPath}
         >
@@ -78,6 +86,7 @@ const CategorySearch = ({
         <Typography>{t('categoriesPage.and')}</Typography>
         <Typography
           component={HashLink}
+          onClick={openCreateNewUserRequestDialog}
           sx={styles.underlineText}
           to={subjectsPath}
         >

--- a/src/constants/request.js
+++ b/src/constants/request.js
@@ -39,5 +39,8 @@ export const URLs = {
     get: '/cooperations',
     create: '/cooperations',
     update: '/cooperations'
+  },
+  userRequest: {
+    create: '/user-requests'
   }
 }

--- a/src/containers/student-home-page/request-new-category/request-new-category-dialog/RequestNewCategoryDialog.jsx
+++ b/src/containers/student-home-page/request-new-category/request-new-category-dialog/RequestNewCategoryDialog.jsx
@@ -9,9 +9,19 @@ import { snackbarVariants } from '~/constants'
 import useForm from '~/hooks/use-form'
 import { useModalContext } from '~/context/modal-context'
 import { useSnackBarContext } from '~/context/snackbar-context'
+import { userRequestService } from '~/services/user-request-service'
 
 import image from '~/assets/img/student-home-page/requestNewCategory.svg'
 import { style } from '~/containers/student-home-page/request-new-category/request-new-category-dialog/RequestNewCategoryDialog.style'
+
+const mapDataToAPIObject = (data) => {
+  const { newSubject, newCategory, additionalInformation } = data
+  return {
+    new_subject: newSubject,
+    category: newCategory,
+    additionalInfo: additionalInformation
+  }
+}
 
 const RequestNewCategoryDialog = () => {
   const { t } = useTranslation()
@@ -27,11 +37,19 @@ const RequestNewCategoryDialog = () => {
     errors
   } = useForm({
     onSubmit: async () => {
-      setAlert({
-        severity: snackbarVariants.success,
-        message: 'studentHomePage.requestNewCategory.successMessage'
-      })
-      closeModal()
+      try {
+        await userRequestService.createUserRequest(mapDataToAPIObject(data))
+        setAlert({
+          severity: snackbarVariants.success,
+          message: 'studentHomePage.requestNewCategory.successMessage'
+        })
+        closeModal()
+      } catch (e) {
+        setAlert({
+          severity: snackbarVariants.error,
+          message: `errors.${e}`
+        })
+      }
     },
     initialValues: {
       newSubject: '',

--- a/src/services/user-request-service.js
+++ b/src/services/user-request-service.js
@@ -1,0 +1,9 @@
+import { URLs } from '~/constants/request'
+import { axiosClient } from '~/plugins/axiosClient'
+import { createUrlPath } from '~/utils/helper-functions'
+
+export const userRequestService = {
+  createUserRequest: (params) => {
+    return axiosClient.post(createUrlPath(URLs.userRequest.create), params)
+  }
+}

--- a/tests/unit/containers/student-home-page/request-new-category/request-new-category-form/RequestNewCategoryForm.spec.jsx
+++ b/tests/unit/containers/student-home-page/request-new-category/request-new-category-form/RequestNewCategoryForm.spec.jsx
@@ -10,12 +10,6 @@ const dataMock = {
   addInformation: 'some additional information'
 }
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key) => key
-  })
-}))
-
 vi.mock('@mui/material/Box', () => ({
   default: (props) => {
     return (


### PR DESCRIPTION
## Created "User Request" service & implemented sending user request data for creating a new category/subject to the server 
<img width="1191" alt="Screenshot 2024-05-29 at 13 29 29" src="https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/d59d2919-c453-4f94-94a9-a758ecafea97">

- [x] **Created a `User Request` service** that can send the data entered by the user in the "`Request a new category`" modal form to the server
- [x] The data entered by the user in the "`Request a new category`" modal form is sent to the server and stored in the "`userRequests`" database:
- **Case 1:** If the user enters a category name that **does not exist in the database**:
<img width="1740" alt="ff" src="https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/701b0e92-a9e8-4887-9ea4-d7fb8dc5e361">

- **Case 2:** If the user enters a category name that **exist in the database**:
<img width="1764" alt="ww" src="https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/e3e59f89-fd0c-474e-9177-abd875f21310">

- [x] If the data entered by the user in the "`Request a new category`" modal form is successfully sent to the server, the user will receive a success alert message - `Success! Your data has been sent.`:
<img width="293" alt="Screenshot 2024-05-27 at 23 14 12" src="https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/415c7481-bb5b-4d39-8605-205e70a23901">

Additionally, [the spec "RequestNewCategoryDialog" was fixed to cover the new functionality.](https://github.com/Space2Study-UA-1156/Client-02/pull/222/commits/3bc77e62e9f2bf8f1305826062694718012fb88c)
_Current Test Coverage:_
<img width="1285" alt="Screenshot 2024-05-29 at 13 24 53" src="https://github.com/Space2Study-UA-1156/Client-02/assets/28622400/ce00e70a-5f9b-4d6e-9b5b-31b6ebda26a9">
